### PR TITLE
Fix keyboard for sr_ME ('rs', not 'sr')

### DIFF
--- a/data/territories.xml
+++ b/data/territories.xml
@@ -12735,7 +12735,7 @@
       <language><languageId>sr</languageId><rank>1000</rank></language>
     </languages>
     <keyboards>
-      <keyboard><keyboardId>sr</keyboardId><rank>1000</rank></keyboard>
+      <keyboard><keyboardId>rs</keyboardId><rank>1000</rank></keyboard>
     </keyboards>
     <inputmethods>
     </inputmethods>


### PR DESCRIPTION
22c833a2a3513a7f7b3dbd6068e832ed4e1da660 missed the sr_ME locale.