### PR TITLE
North cyprus turkish republic #fix

### DIFF
--- a/data/territories.xml
+++ b/data/territories.xml
@@ -5650,6 +5650,7 @@
       <name><languageId>th</languageId><trName>ไซปรัส</trName></name>
       <name><languageId>ti</languageId><trName>ሳይፕረስ</trName></name>
       <name><languageId>tig</languageId><trName>ሳይፕረስ</trName></name>
+      <name><languageId>tr</languageId><trName>Kuzey Kıbrıs Türk Kesimi</trName></name>
       <name><languageId>tr</languageId><trName>Güney Kıbrıs Rum Kesimi</trName></name>
       <name><languageId>ug</languageId><trName>سىپرۇس</trName></name>
       <name><languageId>uk</languageId><trName>Кіпр</trName></name>


### PR DESCRIPTION
Hello ; 

Today I got my report from RH/Turkish/Translation part. Looks like ,there is missing territories in our country part and I added so everyone in Cyprus can also select which one is more suitable for them. 

Thank you.

Bug : https://bugzilla.redhat.com/show_bug.cgi?id=1349245

