### PR TITLE
add list_common_keyboards

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-08-17 Sundeep ANAND <suanand@redhat.com>
+
+	* add list_common_keyboards() to public api
+
 2020-01-14  Mike FABIAN  <mfabian@redhat.com>
 
 	* Parse stuff in glibc locale names after @ which is not a script as a variant

--- a/README
+++ b/README
@@ -50,11 +50,19 @@ import langtable
 
 Functions in the public API:
 
+     parse_locale()
      list_locales()
      list_keyboards()
+     list_common_keyboards()
      list_consolefonts()
+     list_inputmethods()
+     list_timezones()
+     list_scripts()
      language_name()
      territory_name()
+     timezone_name()
+     languageId()
+     territoryId()
      supports_ascii()
 
 Some examples to show the usage are found in the documentation

--- a/test_cases.py
+++ b/test_cases.py
@@ -16,6 +16,7 @@ def dummy():
     >>> from langtable import _test_cldr_locale_pattern
     >>> from langtable import supports_ascii
     >>> from langtable import languageId
+    >>> from langtable import list_common_keyboards
 
     ######################################################################
     # Start of tests to reproduce the results from mangleLocale(inLocale) in anaconda, see:
@@ -2071,6 +2072,24 @@ def dummy():
 
     >>> print(langtable.timezone_name(timezoneId='Pacific/Pago_Pago', languageIdQuery='ast'))  # doctest: +NORMALIZE_WHITESPACE
         Océanu Pacíficu/Pago Pago
+    >>> print(list_common_keyboards())  # doctest: +NORMALIZE_WHITESPACE
+        ['af(ps)', 'al', 'am', 'ara', 'az', 'ba', 'be(oss)', 'bg', 'br', 'bt', 'by', 'ca(eng)', 'ca(ike)', 'ch', 'cn', 'cn(ug)', 'cz', 'de(nodeadkeys)', 'dk', 'ee', 'es', 'es(ast)', 'es(cat)', 'et', 'fi', 'fo', 'fr(bre)', 'fr(oss)', 'gb', 'ge', 'gr', 'hr', 'hu', 'ie(CloGaelach)', 'il', 'in(eng)', 'ir', 'is', 'it', 'jp', 'ke', 'kg', 'kh', 'kr', 'kz', 'la', 'latam', 'lt', 'lv', 'ma(tifinagh)', 'mk', 'mm', 'mn', 'mt', 'mv', 'ng(hausa)', 'ng(igbo)', 'ng(yoruba)', 'no', 'np', 'ph', 'pk', 'pl', 'ro', 'rs', 'rs(latin)', 'ru', 'ru(bak)', 'ru(chm)', 'ru(cv)', 'ru(kom)', 'ru(os_winkeys)', 'ru(sah)', 'ru(tt)', 'ru(udm)', 'ru(xal)', 'se', 'si', 'sk', 'sn', 'syc', 'th', 'tj', 'tm', 'tr', 'tr(crh)', 'tr(ku)', 'tw', 'ua', 'us', 'us(altgr-intl)', 'us(euro)', 'us(intl)', 'uz', 'vn', 'za']
+    >>> print(list_common_keyboards(languageId='fr'))  # doctest: +NORMALIZE_WHITESPACE
+        ['fr(oss)']
+    >>> print(list_common_keyboards(territoryId='CA'))   # doctest: +NORMALIZE_WHITESPACE
+        ['ca(eng)']
+    >>> print(list_common_keyboards(territoryId='FR'))   # doctest: +NORMALIZE_WHITESPACE
+        ['fr(oss)']
+    >>> print(list_common_keyboards(languageId='fr', territoryId='CA'))   # doctest: +NORMALIZE_WHITESPACE
+        ['ca']
+    >>> print(list_common_keyboards(languageId='de', territoryId='FR'))   # doctest: +NORMALIZE_WHITESPACE
+        ['fr(oss)']
+    >>> print(list_common_keyboards(languageId='sr', scriptId='Latn'))   # doctest: +NORMALIZE_WHITESPACE
+        ['rs(latin)']
+    >>> print(list_common_keyboards(languageId='zh', scriptId='Hans'))   # doctest: +NORMALIZE_WHITESPACE
+        ['cn']
+    >>> print(list_common_keyboards(languageId='zh', scriptId='Hans', territoryId='TW'))   # doctest: +NORMALIZE_WHITESPACE
+        ['tw']
     '''
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `get_common_layouts` to list highest ranked keyboard layouts across languages.
refer: [bz1158370](https://bugzilla.redhat.com/show_bug.cgi?id=1158370)

Using this method, [anaconda](https://github.com/rhinstaller/anaconda) can determine: set of major keyboard layouts to place them up in the list.