### PR TITLE
add list_common_locales

### DIFF
--- a/README
+++ b/README
@@ -53,6 +53,7 @@ Functions in the public API:
      parse_locale()
      list_locales()
      list_keyboards()
+     list_common_languages()
      list_common_keyboards()
      list_consolefonts()
      list_inputmethods()

--- a/langtable/langtable.py
+++ b/langtable/langtable.py
@@ -21,6 +21,7 @@
 #     parse_locale()
 #     list_locales()
 #     list_keyboards()
+#     list_common_languages()
 #     list_common_keyboards()
 #     list_consolefonts()
 #     list_inputmethods()
@@ -1910,6 +1911,35 @@ def list_locales(concise=True, show_weights=False, languageId = None, scriptId =
         return ranked_list
     else:
         return _ranked_list_to_list(ranked_list)
+
+def list_common_languages():
+    '''List common languages
+
+    derived from GNOME/gnome-control-center
+        panels/common/cc-common-language.c
+        cc_common_language_get_initial_languages
+
+    which is based on number of speakers.
+
+    **Examples:**
+
+    >>> list_common_languages()
+    ['ar', 'en', 'fr', 'de', 'ja', 'zh', 'ru', 'es']
+
+    '''
+
+    common_locales = list()
+    common_locales.append("ar_EG.UTF-8")
+    common_locales.append("en_US.UTF-8")
+    common_locales.append("fr_FR.UTF-8")
+    common_locales.append("de_DE.UTF-8")
+    common_locales.append("ja_JP.UTF-8")
+    common_locales.append("zh_CN.UTF-8")
+    common_locales.append("ru_RU.UTF-8")
+    common_locales.append("es_ES.UTF-8")
+
+    languages = map(parse_locale, common_locales)
+    return [lang.language for lang in languages]
 
 def list_scripts(concise=True, show_weights=False, languageId = None, scriptId = None, territoryId = None):
     '''List scripts used for a language and/or in a territory

--- a/test_cases.py
+++ b/test_cases.py
@@ -16,6 +16,7 @@ def dummy():
     >>> from langtable import _test_cldr_locale_pattern
     >>> from langtable import supports_ascii
     >>> from langtable import languageId
+    >>> from langtable import list_common_languages
     >>> from langtable import list_common_keyboards
 
     ######################################################################
@@ -2096,7 +2097,10 @@ def dummy():
         ['cn']
     >>> print(list_common_keyboards(languageId='zh', scriptId='Hans', territoryId='TW'))   # doctest: +NORMALIZE_WHITESPACE
         ['tw']
+    >>> print(list_common_languages())   # doctest: +NORMALIZE_WHITESPACE
+        ['ar', 'en', 'fr', 'de', 'ja', 'zh', 'ru', 'es']
     '''
+
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
This is an attempt to determine common/major locales in langtable.

As a starting point, we may refer to `cc_common_language_get_initial_languages` in [gnome-control-center](https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/master/panels/common/cc-common-language.c) which is based on number of speakers.

I feel this may be refined in the future based on other factors like % of speakers using Fedora, or share of desktop users among speakers of these languages, etc. I guess this could be a potential discussion in flock. (_with fedora-infra_)