### PR TITLE
Japanese: prefer anthy over kkc

### DIFF
--- a/langtable/data/languages.xml
+++ b/langtable/data/languages.xml
@@ -20359,8 +20359,8 @@
       <keyboard><keyboardId>jp</keyboardId><rank>1000</rank></keyboard>
     </keyboards>
     <inputmethods>
-      <inputmethod><inputmethodId>ibus/kkc</inputmethodId><rank>900</rank></inputmethod>
-      <inputmethod><inputmethodId>ibus/anthy</inputmethodId><rank>100</rank></inputmethod>
+      <inputmethod><inputmethodId>ibus/anthy</inputmethodId><rank>900</rank></inputmethod>
+      <inputmethod><inputmethodId>ibus/kkc</inputmethodId><rank>100</rank></inputmethod>
     </inputmethods>
     <consolefonts>
       <consolefont><consolefontId>eurlatgr</consolefontId><rank>1000</rank></consolefont>

--- a/langtable/langtable.py
+++ b/langtable/langtable.py
@@ -2080,7 +2080,7 @@ def list_inputmethods(concise=True, show_weights=False, languageId = None, scrip
     List the suitable input methods for the language “Japanese”:
 
     >>> list_inputmethods(languageId="ja")
-    ['ibus/kkc', 'ibus/anthy']
+    ['ibus/anthy', 'ibus/kkc']
 
     So this returns a list of input methods for Japanese. These lists are
     sorted in order of decreasing likelyhood, i.e. the most common
@@ -2089,7 +2089,7 @@ def list_inputmethods(concise=True, show_weights=False, languageId = None, scrip
     One can also list the possible input methods for the territory “Japan”:
 
     >>> list_inputmethods(territoryId="JP")
-    ['ibus/kkc', 'ibus/anthy']
+    ['ibus/anthy', 'ibus/kkc']
     '''
     ranked_inputmethods = {}
     skipTerritory = False


### PR DESCRIPTION
Fedora made this switch as a Change three years ago: https://fedoraproject.org/wiki/Changes/ibus-anthy_for_default_Japanese_IME

but langtable still prefers kkc. At present the langtable data is not used because we don't set input methods in anaconda and GNOME at present uses its own magic table, not langtable. But we should really make GNOME use langtable, so we should also make this change in langtable. @fujiwarat can I think confirm that anthy should be preferred over kkc these days.